### PR TITLE
[SW-2974] Componentes com variação arredondada

### DIFF
--- a/src/components/Badge/Badge.stories.ts
+++ b/src/components/Badge/Badge.stories.ts
@@ -16,5 +16,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: "Hello World",
+    rounded: true,
   },
 };

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -9,10 +9,11 @@ export interface IBadgeProps {
   iconSide?: "right" | "left";
   outline?: boolean;
   opacity?: boolean;
+  rounded?: boolean;
 }
 
 const badgeVariants = cva(
-  "flex h-7 w-fit items-center justify-center gap-1 rounded-3xl px-3 text-xs font-medium",
+  "flex h-7 w-fit items-center justify-center gap-1 px-3 text-xs font-medium",
   {
     variants: {
       color: {
@@ -30,6 +31,9 @@ const badgeVariants = cva(
       },
       full: {
         true: "",
+      },
+      rounded: {
+        true: "rounded-3xl",
       },
     },
     defaultVariants: {
@@ -106,7 +110,7 @@ type BadgeVariantProps = VariantProps<typeof badgeVariants>;
 
 export interface BadgeProps
   extends Omit<React.HTMLProps<HTMLDivElement>, "color" | "label">,
-    Omit<BadgeVariantProps, "outline" | "opacity">,
+    Omit<BadgeVariantProps, "outline" | "opacity" | "rounded">,
     IBadgeProps {}
 
 export const Badge = ({
@@ -117,9 +121,10 @@ export const Badge = ({
   outline = false,
   opacity = false,
   className,
+  rounded = true,
   ...rest
 }: BadgeProps) => {
-  const badgeClasses = twMerge(badgeVariants({ color, outline, opacity }), className);
+  const badgeClasses = twMerge(badgeVariants({ color, outline, opacity, rounded }), className);
 
   return (
     <div className={badgeClasses} {...rest}>

--- a/src/components/Buttons/Button/Button.stories.tsx
+++ b/src/components/Buttons/Button/Button.stories.tsx
@@ -27,5 +27,6 @@ Variations.args = {
   label: "botao",
   disabled: false,
   size: "md",
+  rounded: true,
   onClick: undefined,
 };

--- a/src/components/Buttons/Button/index.tsx
+++ b/src/components/Buttons/Button/index.tsx
@@ -7,11 +7,12 @@ interface ButtonType extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   iconSide?: "left" | "right";
   icon?: ElementType;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  rounded?: boolean;
 }
 
 export type ButtonVariantProps = VariantProps<typeof buttonVariants>;
 
-export const buttonVariants = cva("flex items-center justify-center gap-2 rounded-md", {
+export const buttonVariants = cva("flex items-center justify-center gap-2", {
   variants: {
     variant: {
       primary: [
@@ -55,10 +56,13 @@ export const buttonVariants = cva("flex items-center justify-center gap-2 rounde
       true: ["opacity-40"],
       false: ["opacity-100"],
     },
+    rounded: {
+      true: "rounded-md",
+    },
   },
 });
 
-export interface ButtonProps extends Omit<ButtonVariantProps, "disabled">, ButtonType {}
+export interface ButtonProps extends Omit<ButtonVariantProps, "disabled" | "rounded">, ButtonType {}
 
 const Button = ({
   variant = "primary",
@@ -68,9 +72,10 @@ const Button = ({
   iconSide,
   icon: Icon,
   className,
+  rounded = true,
   onClick,
 }: ButtonProps) => {
-  const buttonClasses = twMerge(buttonVariants({ variant, size, disabled }), className);
+  const buttonClasses = twMerge(buttonVariants({ variant, size, disabled, rounded }), className);
   return (
     <button className={buttonClasses} onClick={onClick}>
       {Icon && iconSide == "right" && <Icon className="h-4 w-4 stroke-2" />}

--- a/src/components/FloatingButton/FloatingButton.stories.tsx
+++ b/src/components/FloatingButton/FloatingButton.stories.tsx
@@ -33,5 +33,6 @@ Variations.args = {
   label: "floating buton",
   size: "md",
   icon: ArrowDownLeftIcon,
+  rounded: true,
   onClick: undefined,
 };

--- a/src/components/FloatingButton/index.tsx
+++ b/src/components/FloatingButton/index.tsx
@@ -5,31 +5,32 @@ import { twMerge } from "tailwind-merge";
 interface FloatingButtonType extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
   icon: ElementType;
+  rounded?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
 export type FloatingButtonVariantProps = VariantProps<typeof buttonVariants>;
 
-export const buttonVariants = cva(
-  "flex items-center justify-center gap-2 rounded-full drop-shadow-lg",
-  {
-    variants: {
-      variant: {
-        primary: ["bg-primary-25", "hover:bg-primary-50", "focus:bg-primary-100", "text-gray-800"],
+export const buttonVariants = cva("flex items-center justify-center gap-2 drop-shadow-lg", {
+  variants: {
+    variant: {
+      primary: ["bg-primary-25", "hover:bg-primary-50", "focus:bg-primary-100", "text-gray-800"],
 
-        invisible: ["bg-white", "hover:bg-gray-50", "focus:bg-gray-100", "text-gray-800"],
-      },
-      size: {
-        lg: ["text-sm", "p-5"],
-        md: ["text-sm", "p-4"],
-        sm: ["text-sm", "p-3"],
-      },
+      invisible: ["bg-white", "hover:bg-gray-50", "focus:bg-gray-100", "text-gray-800"],
+    },
+    size: {
+      lg: ["text-sm", "p-5"],
+      md: ["text-sm", "p-4"],
+      sm: ["text-sm", "p-3"],
+    },
+    rounded: {
+      true: " rounded-full",
     },
   },
-);
+});
 
 export interface FloatingButtonProps
-  extends Omit<FloatingButtonVariantProps, "variant" & "size">,
+  extends Omit<FloatingButtonVariantProps, ("variant" & "size") | "rounded">,
     FloatingButtonType {}
 
 const FloatingButton = ({
@@ -38,9 +39,10 @@ const FloatingButton = ({
   label,
   icon: Icon,
   className,
+  rounded = true,
   onClick,
 }: FloatingButtonProps) => {
-  const buttonClasses = twMerge(buttonVariants({ variant, size }), className);
+  const buttonClasses = twMerge(buttonVariants({ variant, size, rounded }), className);
   return (
     <button className={buttonClasses} onClick={onClick}>
       {<Icon className="h-4 w-4 stroke-2" />}

--- a/src/components/SelectBox/SelectBox.stories.tsx
+++ b/src/components/SelectBox/SelectBox.stories.tsx
@@ -33,4 +33,5 @@ Variations.args = {
   supportText: "texto de suporte",
   leftIcon: EnvelopeIcon,
   error: false,
+  rounded: true,
 };

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -19,11 +19,12 @@ interface SelectBoxType extends ListboxProps<any, any, any> {
   supportText?: string;
   leftIcon?: ElementType;
   error?: boolean;
+  rounded?: boolean;
 }
 
 export type SelectBoxVariantProps = VariantProps<typeof selectBoxVariants>;
 
-export const selectBoxVariants = cva("relative m-1 cursor-default select-none rounded pl-2", {
+export const selectBoxVariants = cva("relative m-1 cursor-default select-none pl-2", {
   variants: {
     size: {
       lg: "x-1 py-3 text-md",
@@ -34,11 +35,14 @@ export const selectBoxVariants = cva("relative m-1 cursor-default select-none ro
       true: "bg-white hover:bg-gray-100",
       false: "text-gray-950",
     },
+    rounded: {
+      true: "rounded",
+    },
   },
 });
 
 export const selectBoxButtonVariants = cva(
-  "relative w-full cursor-default rounded-lg border text-left hover:bg-gray-100",
+  "relative w-full cursor-default border text-left hover:bg-gray-100",
   {
     variants: {
       disabled: {
@@ -57,6 +61,9 @@ export const selectBoxButtonVariants = cva(
       error: {
         true: "border-error-600",
       },
+      rounded: {
+        true: "rounded-lg",
+      },
     },
   },
 );
@@ -69,7 +76,9 @@ export const selectBoxSupportTextVariants = cva("mb-1 block pt-2 text-xs text-gr
   },
 });
 
-export interface SelectBoxProps extends Omit<SelectBoxVariantProps, "size">, SelectBoxType {}
+export interface SelectBoxProps
+  extends Omit<SelectBoxVariantProps, "size" | "rounded">,
+    SelectBoxType {}
 
 function SelectBox({
   options,
@@ -80,6 +89,7 @@ function SelectBox({
   supportText,
   leftIcon: LeftIcon,
   error = false,
+  rounded = true,
   ...rest
 }: SelectBoxProps) {
   const renderChevron = (open: boolean): ReactNode => {
@@ -105,7 +115,7 @@ function SelectBox({
             <div className="relative">
               <Listbox.Button
                 className={twMerge(
-                  selectBoxButtonVariants({ disabled, size, error, open }),
+                  selectBoxButtonVariants({ disabled, size, error, open, rounded }),
                   className,
                 )}
               >
@@ -128,7 +138,7 @@ function SelectBox({
                     <Listbox.Option
                       key={option.value}
                       value={option.value}
-                      className={({ active }) => selectBoxVariants({ size, active })}
+                      className={({ active }) => selectBoxVariants({ size, active, rounded })}
                     >
                       {({ selected }) => (
                         <span

--- a/src/components/TextArea/index.stories.tsx
+++ b/src/components/TextArea/index.stories.tsx
@@ -19,5 +19,6 @@ export const Default: Story = {
     placeholder: "Hello World",
     name: "name",
     disabled: false,
+    rounded: true,
   },
 };

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -20,6 +20,7 @@ export const Default: Story = {
     placeholder: "Hello World",
     name: "name",
     disabled: false,
+    rounded: true,
   },
 };
 
@@ -30,6 +31,7 @@ export const WithIconLeft: Story = {
     leftIcon: XMarkIcon,
     name: "name",
     disabled: false,
+    rounded: true,
   },
 };
 
@@ -41,5 +43,6 @@ export const WithTwoIcons: Story = {
     rightIcon: XMarkIcon,
     name: "name",
     disabled: false,
+    rounded: true,
   },
 };

--- a/src/components/TextField/TextFieldBase.tsx
+++ b/src/components/TextField/TextFieldBase.tsx
@@ -16,10 +16,11 @@ export interface ITextFieldBase
   disabled?: boolean;
   error?: boolean;
   errorMsg?: string;
+  rounded?: boolean;
 }
 
 const TextFieldBaseVariants = cva(
-  "relative my-2 w-full rounded-lg border text-md hover:bg-gray-50 focus:border-primary-100 focus:outline-none",
+  "relative my-2 w-full border text-md hover:bg-gray-50 focus:border-primary-100 focus:outline-none",
   {
     variants: {
       size: {
@@ -34,6 +35,9 @@ const TextFieldBaseVariants = cva(
       leftIconPresent: {
         true: "pl-9",
         false: "pl-3",
+      },
+      rounded: {
+        true: "rounded-lg",
       },
     },
     defaultVariants: {
@@ -58,7 +62,7 @@ const IconVariants = cva("absolute top-1/2 h-6 w-6 text-gray-500", {
 type TextfieldVariantProps = VariantProps<typeof TextFieldBaseVariants>;
 
 export interface TextFieldBaseProps
-  extends Omit<TextfieldVariantProps, "error" | "leftIconPresent">,
+  extends Omit<TextfieldVariantProps, "error" | "leftIconPresent" | "rounded">,
     ITextFieldBase {}
 
 export const TextFieldBase = ({
@@ -74,12 +78,13 @@ export const TextFieldBase = ({
   error = false,
   name,
   errorMsg,
+  rounded = true,
   ...rest
 }: TextFieldBaseProps) => {
   const InputElement = inputElement;
   const leftIconPresent = !!LeftIcon;
   const textfieldClasses = twMerge(
-    TextFieldBaseVariants({ size, error, leftIconPresent }),
+    TextFieldBaseVariants({ size, error, leftIconPresent, rounded }),
     className,
   );
   const opacityClass = disabled ? "opacity-50 relative" : "relative";

--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -21,6 +21,7 @@ export const Variations = Template.bind({});
 Variations.args = {
   color: "primary",
   variant: "tonal",
+  rounded: true,
   message:
     "Porem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum, ac aliquet odio mattis. Class",
   title: "teste",

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -13,13 +13,14 @@ interface ToastType extends HTMLAttributes<any> {
   title: string;
   color?: "primary" | "success" | "warning" | "error";
   message: string;
+  rounded?: boolean;
   onClose?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
 export type ToastVariantProps = VariantProps<typeof toastVariants>;
 
 export const toastVariants = cva(
-  "toast-component flex h-auto w-[327px] justify-between gap-3 rounded-md bg-primary-50 px-4 py-5 text-sm md:w-[541px]",
+  "toast-component flex h-auto w-[327px] justify-between gap-3 bg-primary-50 px-4 py-5 text-sm md:w-[541px]",
   {
     variants: {
       color: {
@@ -31,6 +32,9 @@ export const toastVariants = cva(
       variant: {
         tonal: "border",
         filled: "",
+      },
+      rounded: {
+        true: "rounded-md",
       },
     },
     compoundVariants: [
@@ -57,18 +61,21 @@ export const toastVariants = cva(
     ],
   },
 );
-export interface ToastProps extends Omit<ToastVariantProps, "color" | "variant">, ToastType {}
+export interface ToastProps
+  extends Omit<ToastVariantProps, "color" | "variant" | "rounded">,
+    ToastType {}
 
 const Toast = ({
   variant = "tonal",
   title,
   color = "primary",
   message,
+  rounded = true,
   onClose,
   className,
 }: ToastProps) => {
   const [isClose, setIsClose] = useState(false);
-  const toastClass = twMerge(toastVariants({ color, variant }), className);
+  const toastClass = twMerge(toastVariants({ color, variant, rounded }), className);
 
   const closeToast = () => {
     setIsClose(true);


### PR DESCRIPTION
### Descrição

Adiciona uma variação aos componentes para ficarem arredondados ou não.

### Observações

A variação funciona por meio de uma props chamada rounded com default true

### Prints

![rounded](https://github.com/SwitchDreams/switch-ui/assets/86669458/58b84af9-520b-474e-a812-6228e6ea8330)

### Checklist

- [x] Fiz o link com a task do clickup.
- [x] Fiz minha própria revisão do código.
- [ ] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
