### PR TITLE
[SW-3256] Add the size xs

### DIFF
--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -10,9 +10,10 @@ export interface IText extends HTMLAttributes<any> {
   className?: string;
 }
 
-const TextVariants = cva("text font-default", {
+const TextVariants = cva("font-default", {
   variants: {
     size: {
+      xs: "text-xs",
       sm: "text-sm",
       md: "text-md",
       lg: "text-lg",


### PR DESCRIPTION
### Descrição

Possuia um componente um class text que estava bugando o tamanho sm apenas e ele ficava md, e realmente não possuia a variante xs que foi adicionada.

### Checklist

- [X] Fiz o link com a task do clickup.
- [X] Fiz minha própria revisão do código.
- [X] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
