### PR TITLE
[SW-3258] Sidebar mobile color change

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ const SidebarComponent = ({
   logo,
   absolute,
   sideBarColor = "bg-white",
+  sideBarMobileColor = "bg-white",
   textColor = "text-gray-600",
   hoverColor = "bg-gray-50",
 }: PropsWithChildren & any) => {
@@ -24,6 +25,7 @@ const SidebarComponent = ({
         absolute={absolute}
         sideBarColor={sideBarColor}
         textColor={textColor}
+        sideBarMobileColor={sideBarMobileColor}
       >
         {children}
       </SidebarMain>

--- a/src/components/Sidebar/SidebarMain.tsx
+++ b/src/components/Sidebar/SidebarMain.tsx
@@ -8,6 +8,7 @@ export interface SidebarVariant extends PropsWithChildren, ComponentProps<"div">
   mobileLogo?: string;
   absolute?: boolean;
   sideBarColor?: string;
+  sideBarMobileColor?: string;
   textColor?: string;
 }
 
@@ -16,6 +17,7 @@ const SidebarMain = ({
   absolute,
   children,
   sideBarColor = "bg-white",
+  sideBarMobileColor = "bg-white",
   textColor = "text-gray-100",
   className,
   ...rest
@@ -26,7 +28,7 @@ const SidebarMain = ({
   return (
     <div>
       <div
-        className={`${sideBarColor} ${textColor} absolute top-0 z-0 flex w-full items-center justify-between border-b-2 border-gray-100 py-10 max-md:h-[70px] md:hidden`}
+        className={`${sideBarMobileColor} ${textColor} absolute top-0 z-0 flex w-full items-center justify-between border-b-2 border-gray-100 py-10 max-md:h-[70px] md:hidden`}
       >
         <Bars3Icon
           className="z-10 ml-4 h-7 w-7"


### PR DESCRIPTION
### Descrição

Agora pode ser trocada a cor do navbar do mobile.

### Prints

![image](https://github.com/SwitchDreams/switch-ui/assets/73035103/606ad403-f8f5-48ab-b7e7-42a126e0d9f5)
![image](https://github.com/SwitchDreams/switch-ui/assets/73035103/e9af1ff1-224c-4c18-8fd8-f610c7dc2132)


### Checklist

- [X] Fiz o link com a task do clickup.
- [X] Fiz minha própria revisão do código.
- [X] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
