### PR TITLE
[SW-3754] :sparkles: removes mask from normal input

### DIFF
--- a/src/components/TextField/TextFieldBase.tsx
+++ b/src/components/TextField/TextFieldBase.tsx
@@ -4,6 +4,7 @@ import InputMask from "react-input-mask";
 import { twMerge } from "tailwind-merge";
 
 type InputElement = typeof InputMask | "textarea" | "input";
+
 export interface ITextFieldBase
   extends Omit<React.InputHTMLAttributes<any>, "label" | "placeholder" | "size"> {
   label: string;
@@ -116,8 +117,9 @@ export const TextFieldBase = forwardRef(
           name={name}
           placeholder={placeholder}
           className={textfieldClasses}
-          mask={mask}
-          maskChar={maskChar}
+          // @ts-ignore
+          mask={inputElement === InputMask ? mask : undefined}
+          maskChar={inputElement === InputMask ? maskChar : undefined}
           {...rest}
         />
         {error ? (


### PR DESCRIPTION
### Descrição
<!-- Descreva brevemente o que foi feito na issue -->
- Issue bem simples para remover a poluição da dom com maskChar ou não
### Observações
- Testes manuais

<!-- Nesse tópico coloque algum detalhe que faltou ou um possível ponto de melhoria futuro -->

### Prints

<!-- Em caso de uma issue que envolva alguma tela ou componente, coloque aqui o print -->

### Checklist

- [x] Fiz o link com a task do clickup.
- [x] Fiz minha própria revisão do código.
- [ ] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
