### PR TITLE
[SW-3699] SelectBox não aceita valores padrões de entrada

### DIFF
--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -48,6 +48,16 @@ const iconVariants = cva(
   },
 );
 
+const backgroundVariant = cva("relative", {
+  variants: {
+    size: {
+      small: "h-4 w-4",
+      medium: "h-5 w-5",
+      large: "h-6 w-6",
+    },
+  },
+});
+
 export interface CheckBoxProps
   extends Omit<HTMLProps<HTMLInputElement>, "size" | "disabled" | "shape" | "color" | "name">,
     ICheckBox,
@@ -63,12 +73,7 @@ export const CheckBox = ({
   ...rest
 }: CheckBoxProps) => {
   return (
-    <div className={
-      twMerge(
-        "relative",
-        checkBoxVariants({ size, shape }),
-      )
-    }>
+    <div className={backgroundVariant({ size })}>
       <input
         name={name}
         aria-label={name}


### PR DESCRIPTION
### Descrição

Alinha o check do componente checkbox

### Prints

![Screenshot from 2023-11-08 09-14-56](https://github.com/SwitchDreams/switch-ui/assets/86669458/e7d9d370-26f3-4907-8cd4-2c378bca700a)

### Checklist

- [x] Fiz o link com a task do clickup.
- [x] Fiz minha própria revisão do código.
- [ ] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
