### PR TITLE
[SW-4128] Customização dos ícones do componente Badge

### DIFF
--- a/src/components/Badge/Badge.stories.ts
+++ b/src/components/Badge/Badge.stories.ts
@@ -1,3 +1,4 @@
+import { StarIcon } from "@heroicons/react/20/solid";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Badge } from ".";
@@ -16,5 +17,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: "Hello World",
+    leftIcon: StarIcon,
   },
 };

--- a/src/components/Badge/__tests__/Badge.test.tsx
+++ b/src/components/Badge/__tests__/Badge.test.tsx
@@ -1,3 +1,4 @@
+import { StarIcon } from "@heroicons/react/20/solid";
 import { render, screen } from "@testing-library/react";
 
 import { Badge } from "..";
@@ -11,7 +12,7 @@ describe("Show Badge", () => {
 });
 describe("Badge With icon", () => {
   it("renders the Badge with XMarkIcon on right", () => {
-    render(<Badge label="Hello world" icon iconSide="right" />);
+    render(<Badge label="Hello world" leftIcon={StarIcon} />);
     const badgeComponent = screen.getByText(/Hello world/i);
     const iconElement = badgeComponent.querySelector("svg");
 
@@ -19,7 +20,7 @@ describe("Badge With icon", () => {
     expect(iconElement).toBeInTheDocument();
   });
   it("renders the Badge with XMarkIcon on left", () => {
-    render(<Badge label="Hello world" icon iconSide="left" />);
+    render(<Badge label="Hello world" rightIcon={StarIcon} />);
     const badgeComponent = screen.getByText(/Hello world/i);
     const iconElement = badgeComponent.querySelector("svg");
 

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,12 +1,11 @@
-import { XMarkIcon } from "@heroicons/react/24/solid";
 import { cva, VariantProps } from "class-variance-authority";
-import React from "react";
+import React, { ElementType } from "react";
 import { twMerge } from "tailwind-merge";
 
 export interface IBadgeProps {
   label: string;
-  icon?: boolean;
-  iconSide?: "right" | "left";
+  rightIcon?: ElementType;
+  leftIcon?: ElementType;
   outline?: boolean;
   opacity?: boolean;
   full?: boolean;
@@ -112,8 +111,8 @@ export interface BadgeProps
 
 export const Badge = ({
   label,
-  icon = false,
-  iconSide = "right",
+  leftIcon: LeftIcon,
+  rightIcon: RightIcon,
   color,
   outline = false,
   opacity = false,
@@ -125,9 +124,9 @@ export const Badge = ({
 
   return (
     <div className={badgeClasses} {...rest}>
-      {iconSide === "left" && icon && <XMarkIcon className="h-4 w-4 font-bold" />}
+      {LeftIcon && <LeftIcon className="h-4 w-4" />}
       {label}
-      {iconSide === "right" && icon && <XMarkIcon className="h-4 w-4 font-bold" />}
+      {RightIcon && <RightIcon className="h-4 w-4" />}
     </div>
   );
 };


### PR DESCRIPTION
### Descrição

- Permite que qualquer ícone possa ser colocado no componente Badge
- 
### Prints

![Screenshot from 2024-01-09 20-53-12](https://github.com/SwitchDreams/switch-ui/assets/86669458/af203f6a-ced7-415b-8ea9-4f10b1fa27ea)

### Checklist

- [x] Fiz o link com a task do clickup.
- [x] Fiz minha própria revisão do código.
- [x] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
