### PR TITLE
[SW-4127] Padronizar todos os tipos de input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@switchdreams/ui",
   "private": false,
-  "version": "0.3.4",
+  "version": "0.3.10",
   "type": "module",
   "description": "Biblioteca de Componentes da SwitchDreams",
   "repository": {

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -61,7 +61,7 @@ export const SearchInputOptionsVariants = cva(
 );
 
 export const SearchInputButtonVariants = cva(
-  "rounded-plug-md relative my-2 w-full cursor-default border pl-3 pr-10 text-left text-gray-600 hover:bg-gray-100",
+  "rounded-plug-md relative my-2 w-full cursor-default border pl-3 pr-10 text-left text-gray-600 hover:bg-gray-100  focus:border-primary-100 focus:outline-none ",
   {
     variants: {
       disabled: {

--- a/src/components/TextField/TextFieldBase.tsx
+++ b/src/components/TextField/TextFieldBase.tsx
@@ -24,7 +24,7 @@ export interface ITextFieldBase
 }
 
 const TextFieldBaseVariants = cva(
-  "caretColor rounded-plug-md input my-2 w-full text-ellipsis border text-md hover:bg-gray-50 focus:outline-none ",
+  "caretColor rounded-plug-md input my-2 w-full text-ellipsis border text-md hover:bg-gray-50  focus:border-primary-100 focus:outline-none ",
   {
     variants: {
       size: {


### PR DESCRIPTION
### Descrição

- Padronização do estilo dos inputs

### Observações

- Não consegui arrumar os inputs de data e tempo

### Prints

![inputs](https://github.com/SwitchDreams/switch-ui/assets/86669458/30d0bca8-e7f9-4162-938e-5830f972bec3)

### Checklist

- [x] Fiz o link com a task do clickup.
- [x] Fiz minha própria revisão do código.
- [ ] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
