### PR TITLE
🐛 Fix the tooltip z index

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -78,7 +78,7 @@ const Tooltip = ({
   ...rest
 }: TooltipProps) => (
   <div className="group relative  h-fit w-fit cursor-pointer">
-    <div className="z-20 mx-1">{content}</div>
+    <div className="z-10 mx-1">{content}</div>
     <span className={twMerge(TooltipVariants({ position, color }), className)} {...rest}>
       <div className="z-30 flex flex-col">
         {children ? (


### PR DESCRIPTION
### Descrição

Diminuição do z-index do tooltip para funcionar melhor no scalador.

### Observações

Agora ele possui o mesmo z-index do popover que funciona muito bem.

### Checklist

- [X] Fiz o link com a task do clickup.
- [X] Fiz minha própria revisão do código.
- [X] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
