### PR TITLE
Allow customize TextField support text color

### DIFF
--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -20,6 +20,8 @@ export const Default: Story = {
     placeholder: "Hello World",
     name: "name",
     disabled: false,
+    supportText: "Texto de suporte",
+    supportTextClassName: "",
   },
   parameters: {
     design: {

--- a/src/components/TextField/TextFieldBase.tsx
+++ b/src/components/TextField/TextFieldBase.tsx
@@ -14,6 +14,7 @@ export interface ITextFieldBase
   inputElement: InputElement;
   label?: string;
   supportText?: string;
+  supportTextClassName?: string;
   placeholder?: string;
   leftIcon?: ElementType;
   rightIcon?: ElementType;
@@ -94,6 +95,7 @@ export const TextFieldBase = /* @__PURE__ */ forwardRef(
       label,
       className,
       supportText,
+      supportTextClassName,
       disabled,
       error = false,
       name,
@@ -148,7 +150,12 @@ export const TextFieldBase = /* @__PURE__ */ forwardRef(
             />
           )}
         </div>
-        <SupportOrErrorMessage error={error} errorMsg={errorMsg} supportText={supportText} />
+        <SupportOrErrorMessage
+          error={error}
+          errorMsg={errorMsg}
+          supportText={supportText}
+          supportTextClassName={supportTextClassName}
+        />
       </div>
     );
   },

--- a/src/components/TextField/__tests__/index.test.tsx
+++ b/src/components/TextField/__tests__/index.test.tsx
@@ -173,4 +173,22 @@ describe("Test the icon padding", () => {
 
     expect(inputElement).toHaveClass("pr-9");
   });
+  describe("Textfield renders with custom support text color", () => {
+    it("render textfield", () => {
+      render(
+        <TextField
+          label="Username"
+          placeholder="Enter your username"
+          leftIcon={XMarkIcon}
+          supportText="Enter your username."
+          supportTextClassName="text-yellow-200"
+          name="name"
+          className="text-orange-100"
+        />,
+      );
+      const supportTextElement = screen.getByText("Enter your username.");
+
+      expect(supportTextElement).toHaveClass("text-yellow-200");
+    });
+  });
 });

--- a/src/internal/SupportOrErrorMessage.tsx
+++ b/src/internal/SupportOrErrorMessage.tsx
@@ -1,20 +1,27 @@
 import React from "react";
 import { Text } from "src/components/Text";
+import { twMerge } from "tailwind-merge";
 
 interface ErrorMsgProps {
   error: boolean;
   supportText?: string;
   errorMsg?: string;
+  supportTextClassName?: string;
 }
 
-export const SupportOrErrorMessage = ({ error, supportText, errorMsg }: ErrorMsgProps) => {
+export const SupportOrErrorMessage = ({
+  error,
+  supportText,
+  errorMsg,
+  supportTextClassName,
+}: ErrorMsgProps) => {
   return error && errorMsg ? (
     <Text size="xs" as="span" className="text-error-500">
       {errorMsg}
     </Text>
   ) : (
     supportText && (
-      <Text size="xs" as="span" className="text-coolGray-600">
+      <Text size="xs" as="span" className={twMerge("text-coolGray-600", supportTextClassName)}>
         {supportText}
       </Text>
     )


### PR DESCRIPTION
### Descrição
Permite customizar a cor do `supportText` do `TextField`. Para isso foi criada a props `supportTextClassName`.
Esse PR corresponde a issue: https://github.com/SwitchDreams/switch-ui/issues/136

### Mudança storybook

![updated-storybook](https://github.com/user-attachments/assets/7f283177-742b-46c6-9e30-d435b2663738)

### Checklist

- [ ] Fiz o link com a task do clickup.
- [x] Fiz minha própria revisão do código.
- [x] Realizei os testes que compravam que a funcionalidade está funcionando corretamente.
